### PR TITLE
infinite page children tree support

### DIFF
--- a/src/lib/field-types/Link.svelte
+++ b/src/lib/field-types/Link.svelte
@@ -44,12 +44,26 @@
     }
   }
 
-  function getPageUrl(page, loc) {
+  function getPageUrl(page, loc, pages) {
     const prefix = loc === 'en' ? '/' : `/${loc}/`
     if (page.url === 'index') {
       return prefix
     } else {
-      return prefix + page.url
+      let parent_urls = []
+      if(page.parent) {
+        let no_more_parents = false
+        let grandparent = pages.find(p => p.id === page.parent)
+        parent_urls.push(grandparent.url)
+        while (!no_more_parents){
+          grandparent = pages.find(p => p.id === grandparent.parent)
+          if (!grandparent) {
+            no_more_parents = true
+          } else {
+            parent_urls.unshift(grandparent.url)
+          }
+        }
+      }
+      return parent_urls.length ? prefix + parent_urls.join('/') + '/' + page.url : prefix + page.url
     }
   }
 </script>
@@ -78,9 +92,10 @@
           on:change={() => dispatch('input')}
         >
           {#each $pages as page}
-            <option value={getPageUrl(page, $locale)}>
+            {@const page_url = getPageUrl(page, $locale, $pages)}
+            <option value={page_url}>
               {page.name}
-              <pre>({getPageUrl(page, $locale)})</pre>
+              <pre>({page_url})</pre>
             </option>
             <!-- TODO: Fix this -->
             <!-- {#if page.pages.length > 0}

--- a/src/lib/views/modal/Deploy.js
+++ b/src/lib/views/modal/Deploy.js
@@ -107,15 +107,31 @@ export async function buildSiteBundle({ pages }) {
     })
     const formattedHTML = await beautify.html(html)
 
+    let parent_urls = []
     const parent = pages.find(p => p.id === page.parent)
 
+    if(parent) {
+      let no_more_parents = false
+      let grandparent = parent
+      parent_urls.push(parent.url)
+      while (!no_more_parents){
+        grandparent = pages.find(p => p.id === grandparent.parent)
+        if (!grandparent) {
+          no_more_parents = true
+        } else {
+          parent_urls.unshift(grandparent.url)
+        }
+      }
+      
+    }
+    
     let path
     let full_url = url
     if (url === 'index' || url === '404') {
       path = `${url}.html`
     } else if (parent){
-      path = `${parent.url}/${url}/index.html`
-      full_url = `${parent.url}/${url}`
+      path = `${parent_urls.join('/')}/${url}/index.html`
+      full_url = `${parent_urls.join('/')}/${url}`
     } else {
       path = `${url}/index.html`
     }
@@ -192,7 +208,7 @@ export async function buildSiteBundle({ pages }) {
         content: `<!DOCTYPE html>
         <html lang="en">
           <head>
-            <meta http-equiv="Refresh" content="0; url='${get(page).url.href}'" />
+            <meta http-equiv="Refresh" content="0; url='${get(page).url.origin}/${get(page).params.site}'" />
             <meta charset="UTF-8">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>Primo</title>

--- a/src/lib/views/modal/SitePages/PageList/PageList.svelte
+++ b/src/lib/views/modal/SitePages/PageList/PageList.svelte
@@ -44,7 +44,7 @@
 {#if !creating_page}
   <PrimaryButton
     on:click={() => (creating_page = true)}
-    label="Create Page"
+    label="Create Top Level Page"
     icon="akar-icons:plus"
   />
 {/if}


### PR DESCRIPTION
This is tested and working. I also added:

- Titles to the Page option buttons
- Fixed the edit url to be the base url of the site in Primo instead of the current active page
- Changed the "Create Page" button to "Create Top Level Page"
- Removed the add (+) button from Home Page options

The UI could use some polishing as the more levels you create the less space it has in the page select modal, plus the margins are not ideal. Maybe add a reasonable limit? e.g. 5 ? I only needed 3 tbh.

Please merge BEFORE the corresponding Primo PR.