### PR TITLE
Add toggle to make fields language independent

### DIFF
--- a/src/lib/components/FieldItem.svelte
+++ b/src/lib/components/FieldItem.svelte
@@ -240,6 +240,16 @@
 		{/if}
 	</div>
 
+	<div slot="toggle">
+			<Toggle
+				label="Language Independent"
+				toggled={field.is_language_independent}
+				on:toggle={({ detail }) => {
+					field.is_language_independent = detail
+				}}
+			/>
+	</div>
+
 	<!-- <input type="checkbox" bind:checked={field.is_static} slot="static" /> -->
 
 	{#each field.fields as subfield, i (subfield.id)}

--- a/src/lib/const.js
+++ b/src/lib/const.js
@@ -14,6 +14,7 @@ export const Field = (field = {}) => ({
 	fields: [],
 	options: {},
 	is_static: false,
+	is_language_independent: false,
 	...field
 })
 

--- a/src/lib/converter.js
+++ b/src/lib/converter.js
@@ -166,6 +166,7 @@ export function validate_site_structure_v2(site) {
       fields: [],
       options: {},
       is_static: false,
+      is_language_independent: false,
     }],
     content: {
       en: {
@@ -426,6 +427,7 @@ export function convertFields(fields = [], fn = () => { }) {
       options: field.options || {},
       default: field.default || '',
       is_static: field.is_static || false,
+      is_language_independent: field.is_language_independent || false,
     }
   })
 }

--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -48,6 +48,7 @@ export type Field = {
 	fields: Array<Field>,
 	options: object,
 	is_static: boolean,
+	is_language_independent: false,
 	value?: any
 }
 

--- a/src/lib/stores/helpers.js
+++ b/src/lib/stores/helpers.js
@@ -174,10 +174,18 @@ export function get_content_with_static({ component, symbol, loc }) {
 			const field_value = component.content?.[loc]?.[field.key]
 			// if field is static, use value from symbol content
 			if (field.is_static) {
-				const symbol_value = symbol.content?.[loc]?.[field.key]
+				const symbol_value = field.is_language_independent 
+					? symbol.content?.['en']?.[field.key] 
+					: symbol.content?.[loc]?.[field.key]
 				return {
 					key: field.key,
 					value: symbol_value
+				}
+			} else if (field.is_language_independent) {
+				const default_value = symbol.content?.['en']?.[field.key]
+				return {
+					key: field.key,
+					value: default_value
 				}
 			} else if (field_value !== undefined) {
 				return {
@@ -198,6 +206,7 @@ export function get_content_with_static({ component, symbol, loc }) {
 
 	return _.cloneDeep(content)
 }
+
 
 export function getPageData({ page = get(activePage), site = get(activeSite), loc = get(locale) }) {
 	const page_content = page.content[loc]


### PR DESCRIPTION
I was not able to test these changes at all due to a lack of experience in svelte and missing contribution instructions, however, I really would like to see this feature in a future release for my personal projects.
This would close https://github.com/primocms/primo/issues/374