### PR TITLE
Bug fix: Language Field Value overwritten 

### DIFF
--- a/src/lib/views/modal/ComponentEditor/ComponentEditor.svelte
+++ b/src/lib/views/modal/ComponentEditor/ComponentEditor.svelte
@@ -74,7 +74,7 @@
 	// local copy of component content to modify & save
 	let local_content = get_local_content()
 	function get_local_content() {
-		let combined_content = symbol.content
+		let combined_content = component.content
 		symbol.fields.forEach((field) => {
 			if (field.is_static) {
 				const value = symbol.content[$locale][field.key]


### PR DESCRIPTION
Fixes bug that caused content from one language to be overwritten and reset to the symbols default content if the user updated the field value from another language.

This was because the `combined_content` variable was being pulled from the symbol instead of the component.